### PR TITLE
Changed format of metrics types published to file as a JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ It's used in the [snap framework](http://github.com/intelsdi-x/snap).
   * [Installation](#installation)
   * [Configuration and Usage](#configuration-and-usage)
 2. [Documentation](#documentation)
-  * [Collected Metrics](#collected-metrics)
   * [Examples](#examples)
   * [Roadmap](#roadmap)
 3. [Community Support](#community-support)
@@ -50,197 +49,188 @@ This builds the plugin in `./build/rootfs/`
 `export SNAP_PATH=$GOPATH/src/github.com/intelsdi-x/snap/build`
 
 ## Documentation
-To use this plugin you have to specify a config with the location of the file you want to write to:
+To use this plugin you have to specify a config with the location of the file you want to write to.
 
 ```
 # JSON
 "config": {
-    "file": "/tmp/snap_published_file.log"
+    "file": "/tmp/snap_published_file.json"
 }
 
 # YAML
 config: 
-    file: "/tmp/snap_published_mock_file.log"
+    file: "/tmp/snap_published_mock_file.json"
 
 ```
 
 The plugin will write out all metrics serialized as JSON to the specified file. An example of this output is below:
 
-```
+```json
 [
-    {
-        "namespace": [
-            {
-                "Value": "intel",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "mock",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "foo",
-                "Description": "",
-                "Name": ""
-            }
-        ],
-        "last_advertised_time": "2016-07-13T10:39:47.922391602-07:00",
-        "version": 0,
-        "config": {
-            "name": "root",
-            "password": "secret"
-        },
-        "data": 88,
-        "tags": {
-            "plugin_running_on": "testhost.local"
-        },
-        "Unit_": "",
-        "description": "",
-        "timestamp": "2016-07-13T10:40:27.183090674-07:00"
+  {
+    "timestamp": "2016-07-25T11:27:59.795513984+02:00",
+    "namespace": "/intel/mock/host0/baz",
+    "data": 86,
+    "unit": "",
+    "tags": {
+      "plugin_running_on": "my-machine"
     },
-    {
-        "namespace": [
-            {
-                "Value": "intel",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "mock",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "host0",
-                "Description": "name of the host",
-                "Name": "host"
-            },
-            {
-                "Value": "baz",
-                "Description": "",
-                "Name": ""
-            }
-        ],
-        "last_advertised_time": "0001-01-01T00:00:00Z",
-        "version": 0,
-        "config": null,
-        "data": 66,
-        "tags": {
-            "plugin_running_on": "testhost.local"
-        },
-        "Unit_": "",
-        "description": "",
-        "timestamp": "2016-07-13T10:40:27.183093127-07:00"
+    "version": 0,
+    "last_advertised_time": "0001-01-01T00:00:00Z"
+  },
+  {
+    "timestamp": "2016-07-25T11:27:59.795514856+02:00",
+    "namespace": "/intel/mock/host1/baz",
+    "data": 70,
+    "unit": "",
+    "tags": {
+      "plugin_running_on": "my-machine"
     },
-    {
-        "namespace": [
-            {
-                "Value": "intel",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "mock",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "host1",
-                "Description": "name of the host",
-                "Name": "host"
-            },
-            {
-                "Value": "baz",
-                "Description": "",
-                "Name": ""
-            }
-        ],
-        "last_advertised_time": "0001-01-01T00:00:00Z",
-        "version": 0,
-        "config": null,
-        "data": 69,
-        "tags": {
-            "plugin_running_on": "testhost.local"
-        },
-        "Unit_": "",
-        "description": "",
-        "timestamp": "2016-07-13T10:40:27.183094592-07:00"
+    "version": 0,
+    "last_advertised_time": "0001-01-01T00:00:00Z"
+  },
+  {
+    "timestamp": "2016-07-25T11:27:59.795548989+02:00",
+    "namespace": "/intel/mock/bar",
+    "data": 82,
+    "unit": "",
+    "tags": {
+      "plugin_running_on": "my-machine"
     },
-    {
-        "namespace": [
-            {
-                "Value": "intel",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "mock",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "host2",
-                "Description": "name of the host",
-                "Name": "host"
-            },
-            {
-                "Value": "baz",
-                "Description": "",
-                "Name": ""
-            }
-        ],
-        "last_advertised_time": "0001-01-01T00:00:00Z",
-        "version": 0,
-        "config": null,
-        "data": 80,
-        "tags": {
-            "plugin_running_on": "testhost.local"
-        },
-        "Unit_": "",
-        "description": "",
-        "timestamp": "2016-07-13T10:40:27.183096041-07:00"
+    "version": 0,
+    "last_advertised_time": "2016-07-25T11:27:21.852064032+02:00"
+  },
+  {
+    "timestamp": "2016-07-25T11:27:59.795549268+02:00",
+    "namespace": "/intel/mock/foo",
+    "data": 72,
+    "unit": "",
+    "tags": {
+      "plugin_running_on": "my-machine"
     },
-    {
-        "namespace": [
-            {
-                "Value": "intel",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "mock",
-                "Description": "",
-                "Name": ""
-            },
-            {
-                "Value": "host3",
-                "Description": "name of the host",
-                "Name": "host"
-            },
-            {
-                "Value": "baz",
-                "Description": "",
-                "Name": ""
-            }
-        ],
-        "last_advertised_time": "0001-01-01T00:00:00Z",
-        "version": 0,
-        "config": null,
-        "data": 67,
-        "tags": {
-            "plugin_running_on": "testhost.local"
-        },
-        "Unit_": "",
-        "description": "",
-        "timestamp": "2016-07-13T10:40:27.183096841-07:00"
-    }
+    "version": 0,
+    "last_advertised_time": "2016-07-25T11:27:21.852063228+02:00"
+  }
 ]
 ```
 
 ### Examples
-Full task configs using the mock and psutil plugins are available in [examples](examples)
+See full task manifests using the mock and psutil plugins which are available in [examples](examples)  
+
+
+Example of running mock collector plugin, passthru processor plugin, and writing data as a JSON to file:
+
+Make sure that your `$SNAP_PATH` is set, if not:
+```
+$ export SNAP_PATH=<snapDirectoryPath>/build
+```
+In one terminal window, open the snap daemon (in this case with logging set to 1 and trust disabled):
+```
+$ $SNAP_PATH/bin/snapd -l 1 -t 0
+```
+In another terminal window:  
+Load snap-plugin-publisher-file plugin:
+```
+$ $SNAP_PATH/bin/snapctl plugin load build/rootfs/snap-plugin-publisher-file
+
+Plugin loaded
+Name: file
+Version: 2
+Type: publisher
+Signed: false
+Loaded Time: Mon, 25 Jul 2016 12:30:25 CEST
+```
+Load snap-plugin-processor-passthru plugin:
+```
+$ $SNAP_PATH/bin/snapctl plugin load $SNAP_PATH/plugin/snap-plugin-processor-passthru
+
+Plugin loaded
+Name: passthru
+Version: 1
+Type: processor
+Signed: false
+Loaded Time: Mon, 25 Jul 2016 12:33:00 CEST
+```
+
+Load snap-plugin-collector-mock2 plugin:
+```
+$ $SNAP_PATH/bin/snapctl plugin load $SNAP_PATH/plugin/snap-plugin-collector-mock2
+
+Plugin loaded
+Name: mock
+Version: 2
+Type: collector
+Signed: false
+Loaded Time: Mon, 25 Jul 2016 12:32:09 CEST
+```
+
+See available metrics for your system:
+```
+$ $SNAP_PATH/bin/snapctl metric list
+```
+
+Create a task manifest to use File publisher plugin (see [exemplary task manifest](examples/tasks/mock.json)):
+```json
+{
+    "version": 1,
+    "schedule": {
+        "type": "simple",
+        "interval": "1s"
+    },
+    "max-failures": 10,
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/mock/foo": {},
+                "/intel/mock/bar": {},
+                "/intel/mock/*/baz": {}
+            },
+            "config": {
+                "/intel/mock": {
+                    "name": "root",
+                    "password": "secret"
+                }
+            },
+            "process": [
+                {
+                    "plugin_name": "passthru",                    
+                    "process": null,
+                    "publish": [
+                        {
+                            "plugin_name": "file",                            
+                            "config": {
+                                "file": "/tmp/snap_published_mock_file.json"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+```
+
+Create a task:
+```
+$ $SNAP_PATH/bin/snapctl task create -t examples/tasks/mock.json
+Using task manifest to create task
+Task created
+ID: 02dd7ff4-8106-47e9-8b86-70067cd0a850
+Name: Task-02dd7ff4-8106-47e9-8b86-70067cd0a850
+State: Running
+```
+
+See JSON file containing the published data:
+```
+tail -f /tmp/snap_published_mock_file.json
+```
+
+To stop previously created task:
+```
+$ $SNAP_PATH/bin/snapctl task stop 02dd7ff4-8106-47e9-8b86-70067cd0a850
+Task stopped:
+ID: 02dd7ff4-8106-47e9-8b86-70067cd0a850
+```
 
 ### Roadmap
 

--- a/examples/tasks/mock.json
+++ b/examples/tasks/mock.json
@@ -8,14 +8,16 @@
     "workflow": {
         "collect": {
             "metrics": {
-                "/intel/psutil/load/load1": {},
-                "/intel/psutil/load/load15": {},
-                "/intel/psutil/load/load5": {},
-                "/intel/psutil/vm/available": {},
-                "/intel/psutil/vm/free": {},
-                "/intel/psutil/vm/used": {}
+                "/intel/mock/foo": {},
+                "/intel/mock/bar": {},
+                "/intel/mock/*/baz": {}
             },
-            "config": {},
+            "config": {
+                "/intel/mock": {
+                    "name": "root",
+                    "password": "secret"
+                }
+            },
             "process": [
                 {
                     "plugin_name": "passthru",                    
@@ -24,7 +26,7 @@
                         {
                             "plugin_name": "file",                            
                             "config": {
-                                "file": "/tmp/snap_published_file.log"
+                                "file": "/tmp/snap_published_mock_file.json"
                             }
                         }
                     ]

--- a/examples/tasks/mock.yml
+++ b/examples/tasks/mock.yml
@@ -22,4 +22,4 @@
             - 
               plugin_name: "file"
               config: 
-                file: "/tmp/snap_published_mock_file.log"
+                file: "/tmp/snap_published_mock_file.json"

--- a/examples/tasks/psutil.json
+++ b/examples/tasks/psutil.json
@@ -8,16 +8,14 @@
     "workflow": {
         "collect": {
             "metrics": {
-                "/intel/mock/foo": {},
-                "/intel/mock/bar": {},
-                "/intel/mock/*/baz": {}
+                "/intel/psutil/load/load1": {},
+                "/intel/psutil/load/load15": {},
+                "/intel/psutil/load/load5": {},
+                "/intel/psutil/vm/available": {},
+                "/intel/psutil/vm/free": {},
+                "/intel/psutil/vm/used": {}
             },
-            "config": {
-                "/intel/mock": {
-                    "name": "root",
-                    "password": "secret"
-                }
-            },
+            "config": {},
             "process": [
                 {
                     "plugin_name": "passthru",                    
@@ -26,7 +24,7 @@
                         {
                             "plugin_name": "file",                            
                             "config": {
-                                "file": "/tmp/snap_published_mock_file.log"
+                                "file": "/tmp/snap_published_file.json"
                             }
                         }
                     ]

--- a/examples/tasks/psutil.yml
+++ b/examples/tasks/psutil.yml
@@ -22,4 +22,4 @@
             -
               plugin_name: "file"
               config:
-                file: "/tmp/snap_published_file.log"
+                file: "/tmp/snap_published_file.json"


### PR DESCRIPTION
Regarding to https://github.com/intelsdi-x/snap-plugin-publisher-file/issues/4

### Summary of changes:
- added formatting "the metrics to publish" based on incoming metrics types
- updated README.md
  -  updated example of data output
  - added to section *Examples* scenario of running task
 - removed paragraph *CollectedMetrics* (inadequate for publisher plugin)
- removed unused func `formatMetricTagsAsString()`

### Before:

Before the published data looks like below:
```
[
    {
        "namespace": [
            {
                "Value": "intel",
                "Description": "",
                "Name": ""
            },
            {
                "Value": "mock",
                "Description": "",
                "Name": ""
            },
            {
                "Value": "foo",
                "Description": "",
                "Name": ""
            }
        ],
        "last_advertised_time": "2016-07-13T10:39:47.922391602-07:00",
        "version": 0,
        "config": {
            "name": "root",
            "password": "secret"
        },
        "data": 88,
        "tags": {
            "plugin_running_on": "testhost.local"
        },
        "Unit_": "",
        "description": "",
        "timestamp": "2016-07-13T10:40:27.183090674-07:00"
    }
 ]
```
Notice that `namespace` is represented by core.Namespace struct and could be illegible to publish it in that form.

### After changes:
- publish namespace as a single string
- do not publish config items (can contain passwd and so on; moreover, tags should be used to expose an additional information)
- do not publish metric's description (overhead)
- changed the order of published metric's fields
```
 [
   {
    "timestamp": "2016-07-25T11:27:59.795549268+02:00",
    "namespace": "/intel/mock/foo",
    "data": 72,
    "unit": "",
    "tags": {
      "plugin_running_on": "my-machine"
    },
    "version": 0,
    "last_advertised_time": "2016-07-25T11:27:21.852063228+02:00"
  }
]
```  


### Tests done:
- unit tests

@intelsdi-x/plugin-maintainers 